### PR TITLE
[TASK] UsergroupToRemove is detemined by newsletter receiver group

### DIFF
--- a/Classes/Controller/FrontendController.php
+++ b/Classes/Controller/FrontendController.php
@@ -134,7 +134,7 @@ class FrontendController extends ActionController
         if ($hash === '') {
             throw new \InvalidArgumentException('Hash not given', 1562050533);
         }
-        $usergroupToRemove = $this->usergroupRepository->findByUid((int)$this->settings['removeusergroup']);
+        $usergroupToRemove = $newsletter->getReceiver();
         if ($user->getUsergroup()->contains($usergroupToRemove) === false) {
             throw new \LogicException('Usergroup not assigned to user', 1562066292);
         }

--- a/Classes/Controller/FrontendController.php
+++ b/Classes/Controller/FrontendController.php
@@ -93,7 +93,7 @@ class FrontendController extends ActionController
         try {
             $this->checkArgumentsForUnsubscribeAction($user, $newsletter, $hash);
             /** @var Usergroup $usergroupToRemove */
-            $usergroupToRemove = $this->usergroupRepository->findByUid((int)$this->settings['removeusergroup']);
+            $usergroupToRemove = $newsletter->getReceiver();
             $user->removeUsergroup($usergroupToRemove);
             $this->userRepository->update($user);
             $this->userRepository->persistAll();


### PR DESCRIPTION
Uses the receiver group bound to the newsletter object in unsubscription context instead of 'static' flexform setting
