### PR TITLE
Add settings and variables to NewsletterContainer rendering

### DIFF
--- a/Tests/Functional/Domain/Service/ParseNewsletterUrlServiceTest.php
+++ b/Tests/Functional/Domain/Service/ParseNewsletterUrlServiceTest.php
@@ -1,0 +1,220 @@
+<?php
+namespace In2code\Luxletter\Tests\Functional\Domain\Service;
+
+use In2code\Luxletter\Domain\Factory\UserFactory;
+use In2code\Luxletter\Domain\Model\User;
+use In2code\Luxletter\Domain\Service\ParseNewsletterService;
+use In2code\Luxletter\Domain\Service\ParseNewsletterUrlService;
+use In2code\Luxletter\Utility\ObjectUtility;
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Class ParseNewsletterUrlServiceTest
+ * @coversDefaultClass \In2code\Luxletter\Domain\Service\ParseNewsletterUrlService
+ */
+class ParseNewsletterUrlServiceTest extends FunctionalTestCase
+{
+    /**
+     * @var ParseNewsletterUrlService
+     */
+    protected $subject;
+
+    /**
+     * @var ObjectManagerInterface|ObjectProphecy
+     */
+    protected $objectManager;
+
+    /**
+     * @var ConfigurationManagerInterface|ObjectProphecy
+     */
+    protected $configurationManager;
+
+    /**
+     * @var UserFactory|ObjectProphecy
+     */
+    protected $userFactory;
+
+    /**
+     * @var ParseNewsletterService|ObjectProphecy
+     */
+    protected $parseNewsletterService;
+
+    /**
+     * @var StandaloneView|ObjectProphecy
+     */
+    protected $standaloneView;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->subject = ObjectUtility::getObjectManager()->get(ParseNewsletterUrlService::class, 'http://example.com/');
+
+        /** @var Dispatcher|ObjectProphecy $dispatcher */
+        $dispatcher = $this->prophesize(Dispatcher::class);
+        $dispatcher
+            ->dispatch(Argument::cetera())
+            ->willReturn([]);
+
+        $user = new User();
+        $user->setEmail('dummy@example.com');
+        $user->setFirstName('Max');
+        $user->setLastName('Mustermann');
+
+        $this->userFactory = $this->prophesize(UserFactory::class);
+        $this->userFactory
+            ->getDummyUser()
+            ->shouldBeCalled()
+            ->willReturn($user);
+
+        $this->parseNewsletterService = $this->prophesize(ParseNewsletterService::class);
+        $this->parseNewsletterService
+            ->parseMailText(Argument::cetera())
+            ->shouldBeCalled()
+            ->willReturn('<div>Hello</div>');
+
+        $this->configurationManager = $this->prophesize(ConfigurationManager::class);
+
+        $this->standaloneView = $this->prophesize(StandaloneView::class);
+        $this->standaloneView
+            ->setTemplateRootPaths([])
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->setLayoutRootPaths([])
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->setPartialRootPaths([])
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->setTemplate('Mail/NewsletterContainer.html')
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->render()
+            ->shouldBeCalled()
+            ->willReturn('');
+
+        /** @var TypoScriptFrontendController|ObjectProphecy $tsfe */
+        $tsfeProphecy = $this->prophesize(TypoScriptFrontendController::class);
+
+        $this->objectManager = $this->prophesize(ObjectManager::class);
+        $this->objectManager
+            ->get(Dispatcher::class)
+            ->shouldBeCalled()
+            ->willReturn($dispatcher->reveal());
+        $this->objectManager
+            ->get(UserFactory::class)
+            ->shouldBeCalled()
+            ->willReturn($this->userFactory->reveal());
+        $this->objectManager
+            ->get(ParseNewsletterService::class)
+            ->shouldBeCalled()
+            ->willReturn($this->parseNewsletterService->reveal());
+        $this->objectManager
+            ->get(ConfigurationManager::class)
+            ->shouldBeCalled()
+            ->willReturn($this->configurationManager->reveal());
+        $this->objectManager
+            ->get(StandaloneView::class)
+            ->shouldBeCalled()
+            ->willReturn($this->standaloneView->reveal());
+        $this->objectManager
+            ->get(TypoScriptService::class)
+            ->shouldBeCalled()
+            ->willReturn(new TypoScriptService());
+        $this->objectManager
+            ->get(ContentObjectRenderer::class)
+            ->shouldBeCalled()
+            ->willReturn(new ContentObjectRenderer($tsfeProphecy->reveal()));
+        GeneralUtility::setSingletonInstance(ObjectManager::class, $this->objectManager->reveal());
+    }
+
+    protected function tearDown()
+    {
+        unset(
+            $this->subject,
+            $this->objectManager,
+            $this->userFactory,
+            $this->parseNewsletterService,
+            $this->configurationManager,
+            $this->standaloneView
+        );
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function getParsedContentWithNoUserWillAddFluidSettings()
+    {
+        $this->configurationManager
+            ->getConfiguration('Framework', 'luxletter')
+            ->shouldBeCalled()
+            ->willReturn([
+                'view' => [
+                    'templateRootPaths' => [],
+                    'layoutRootPaths' => [],
+                    'partialRootPaths' => [],
+                ],
+                'settings' => [
+                    'foo' => 'bar'
+                ]
+            ]);
+
+        $this->standaloneView
+            ->assignMultiple(Argument::cetera())
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->assign('settings', ['foo' => 'bar'])
+            ->shouldBeCalled();
+
+        $this->subject->getParsedContent();
+    }
+
+    /**
+     * @test
+     */
+    public function getParsedContentWithNoUserWillAddFluidVariables()
+    {
+        $this->configurationManager
+            ->getConfiguration('Framework', 'luxletter')
+            ->shouldBeCalled()
+            ->willReturn([
+                'view' => [
+                    'templateRootPaths' => [],
+                    'layoutRootPaths' => [],
+                    'partialRootPaths' => [],
+                ],
+                'variables' => [
+                    'subject' => [
+                        '_typoScriptNodeValue' => 'TEXT',
+                        'value' => 'Hello world'
+                    ]
+                ]
+            ]);
+
+        $this->standaloneView
+            ->assignMultiple([
+                'subject' => 'Hello world'
+            ])
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->assignMultiple(Argument::cetera())
+            ->shouldBeCalled();
+        $this->standaloneView
+            ->assign('settings', [])
+            ->shouldBeCalled();
+
+        $this->subject->getParsedContent();
+    }
+}


### PR DESCRIPTION
With this PR it will be possible to add static `settings` and ContentObject-based `variables` to NewsletterContainer as known from FLUIDTEMPLATE.

Now you can add settings and variables that way:
```
plugin {
  tx_luxletter_fe {
    settings {
      foo = bar
    }
    variables {
      subject = TEXT
      subject.value = My own Newsletter
    }
  }
}
```

Would be cool to have that feature in your extension

Stefan