### PR TITLE
[FEATURE] Add Signal to BeforeParsing

### DIFF
--- a/Classes/Domain/Service/ParseNewsletterUrlService.php
+++ b/Classes/Domain/Service/ParseNewsletterUrlService.php
@@ -103,7 +103,6 @@ class ParseNewsletterUrlService
         $templateName = 'Mail/NewsletterContainer.html';
         if ($this->isParsingActive()) {
             $configuration = ConfigurationUtility::getExtensionSettings();
-            $this->signalDispatch(__CLASS__, __FUNCTION__ . 'BeforeParsing', [$content, &$configuration, $user, $this]);
             $standaloneView = ObjectUtility::getObjectManager()->get(StandaloneView::class);
             $standaloneView->setTemplateRootPaths($configuration['view']['templateRootPaths']);
             $standaloneView->setLayoutRootPaths($configuration['view']['layoutRootPaths']);
@@ -116,6 +115,11 @@ class ParseNewsletterUrlService
                     'user' => $user,
                     'settings' => $configuration['settings'] ?? []
                 ]
+            );
+            $this->signalDispatch(
+                __CLASS__,
+                __FUNCTION__ . 'PostParsing',
+                [$standaloneView, $content, &$configuration, $user, $this]
             );
             $html = $standaloneView->render();
         } else {

--- a/Classes/Domain/Service/ParseNewsletterUrlService.php
+++ b/Classes/Domain/Service/ParseNewsletterUrlService.php
@@ -103,6 +103,7 @@ class ParseNewsletterUrlService
         $templateName = 'Mail/NewsletterContainer.html';
         if ($this->isParsingActive()) {
             $configuration = ConfigurationUtility::getExtensionSettings();
+            $this->signalDispatch(__CLASS__, __FUNCTION__ . 'BeforeParsing', [$content, &$configuration, $user, $this]);
             $standaloneView = ObjectUtility::getObjectManager()->get(StandaloneView::class);
             $standaloneView->setTemplateRootPaths($configuration['view']['templateRootPaths']);
             $standaloneView->setLayoutRootPaths($configuration['view']['layoutRootPaths']);

--- a/Classes/Domain/Service/ParseNewsletterUrlService.php
+++ b/Classes/Domain/Service/ParseNewsletterUrlService.php
@@ -119,7 +119,7 @@ class ParseNewsletterUrlService
             $this->signalDispatch(
                 __CLASS__,
                 __FUNCTION__ . 'PostParsing',
-                [$standaloneView, $content, &$configuration, $user, $this]
+                [$standaloneView, $content, $configuration, $user, $this]
             );
             $html = $standaloneView->render();
         } else {


### PR DESCRIPTION
As getNewsletterContainerAndContent does not
contain a page-related configuration we will
add a new SignalSlot where developers can add individual
Settings/Variables/Configuration for Fluid rendering.

Resolves: #47