### PR TITLE
[TASK] Add origin to ParseNewsletterUrlService

### DIFF
--- a/Classes/Domain/Service/ParseNewsletterUrlService.php
+++ b/Classes/Domain/Service/ParseNewsletterUrlService.php
@@ -29,6 +29,13 @@ class ParseNewsletterUrlService
     use SignalTrait;
 
     /**
+     * Hold origin
+     *
+     * @var string
+     */
+    protected $origin = '';
+
+    /**
      * Hold url from origin
      *
      * @var string
@@ -64,6 +71,7 @@ class ParseNewsletterUrlService
             $url = $origin;
         }
         $this->signalDispatch(__CLASS__, 'constructor', [$url, $origin, $this]);
+        $this->setOrigin($origin);
         $this->setUrl($url);
     }
 
@@ -235,6 +243,22 @@ class ParseNewsletterUrlService
     {
         $this->parseVariables = $parseVariables;
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrigin(): string
+    {
+        return $this->origin;
+    }
+
+    /**
+     * @param string $origin
+     */
+    public function setOrigin(string $origin)
+    {
+        $this->origin = $origin;
     }
 
     /**


### PR DESCRIPTION
As $this->url was built within the constructor
it is not possible for developers to access the
original origin, we the page UID is located.
Instead of trying to convert the url back to an UID,
we will add the origin as property to
ParseNewsletterUrlService

Resolves: #49