### PR TITLE
#22863 [BUGFIX] use callByReference in SignalSlots

### DIFF
--- a/Classes/Domain/Service/ParseNewsletterUrlService.php
+++ b/Classes/Domain/Service/ParseNewsletterUrlService.php
@@ -134,7 +134,7 @@ class ParseNewsletterUrlService
             $container = file_get_contents(TemplateUtility::getExistingFilePathOfTemplateFileByName($templateName));
             $html = str_replace('{content}', $content, $container);
         }
-        $this->signalDispatch(__CLASS__, __FUNCTION__, [$html, $content, $user, $this]);
+        $this->signalDispatch(__CLASS__, __FUNCTION__, [&$html, &$content, $user, $this]);
         return $html;
     }
 


### PR DESCRIPTION
Signal Slots are not made to view the variables...
they are made to manipulate the values... So we need call by reference to all parameters that are allowed to change
