### PR TITLE
Check fe_user if is not deleted or disabled

### DIFF
--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -26,7 +26,9 @@ class QueueRepository extends AbstractRepository
         $and = [
             $query->lessThan('datetime', time()),
             $query->equals('sent', false),
-            $query->equals('newsletter.disabled', false)
+            $query->equals('newsletter.disabled', false),
+            $query->equals('user.deleted', false),
+            $query->equals('user.disable', false)
         ];
         $query->matching($query->logicalAnd($and));
         $query->setLimit($limit);


### PR DESCRIPTION
If a user is in the queue and then deleted, it will generate errors as there is no further check.