### PR TITLE
update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
   },
   "extra": {
     "typo3/cms": {
+      "extension-key": "luxletter"
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "web-dir": ".Build/Web"
     }


### PR DESCRIPTION
Not providing "extension-key"-property will emit a deprecation notice and will fail in future versions.
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra