### PR TITLE
update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
-      "web-dir": ".Build/Web"
+      "web-dir": ".Build/Web",
+      "extension-key": "luxletter"
     }
   }
 }


### PR DESCRIPTION
Not providing "extension-key"-property will emit a deprecation notice and will fail in future versions.
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra