### PR TITLE
[TASK] Improve signals in ParseNewsletterService

### DIFF
--- a/Classes/Domain/Service/ParseNewsletterService.php
+++ b/Classes/Domain/Service/ParseNewsletterService.php
@@ -30,6 +30,7 @@ class ParseNewsletterService
     public function parseSubject(string $subject, array $properties): string
     {
         $this->signalDispatch(__CLASS__, __FUNCTION__, [&$subject, $properties, $this]);
+        $properties['type'] = 'subject';
         return $this->parseMailText($subject, $properties);
     }
 
@@ -45,6 +46,7 @@ class ParseNewsletterService
     public function parseBodytext(string $bodytext, array $properties): string
     {
         $this->signalDispatch(__CLASS__, __FUNCTION__, [&$bodytext, $properties, $this]);
+        $properties['type'] = 'bodytext';
         return $this->parseMailText($bodytext, $properties);
     }
 
@@ -66,7 +68,6 @@ class ParseNewsletterService
         $standaloneView->setLayoutRootPaths($configuration['view']['layoutRootPaths']);
         $standaloneView->setPartialRootPaths($configuration['view']['partialRootPaths']);
         $standaloneView->setTemplateSource($text);
-        $this->signalDispatch(__CLASS__, __FUNCTION__ . 'BeforeAssignment', [$properties, $this]);
         $standaloneView->assignMultiple($properties);
         $string = $standaloneView->render();
         $this->signalDispatch(__CLASS__, __FUNCTION__, [&$string, $properties, $this]);


### PR DESCRIPTION
I checked out the new implementation and I suggest the following changes:

* The new methods `parseSubject` and `parseBodytext` have their dedicated signal slot, therefore the introduced `BeforeAssignment` slot is not needed
* To be able to really use the slot in `parseMailText` as kind of *afterRender*, it needs the information if the bodytext or subject is processed.

With those changes it is now possible to:

* use the previous slot for afterRendering and know without guessing if it is bodytext or subject
* have 2 new slots for preRendering and because of its dedicated methods it is also clear which content is processed