### PR TITLE
[BUGFIX] Adjust SQL definition to fulfill mysql strict mode

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -10,7 +10,7 @@ CREATE TABLE tx_luxletter_domain_model_newsletter (
 	configuration int(11) DEFAULT '0' NOT NULL,
 	layout varchar(255) DEFAULT '' NOT NULL,
 	origin varchar(255) DEFAULT '' NOT NULL,
-	bodytext mediumtext NOT NULL,
+	bodytext mediumtext,
 	disabled tinyint(4) unsigned DEFAULT '0' NOT NULL,
 	language int(11) DEFAULT '0' NOT NULL,
 
@@ -70,7 +70,7 @@ CREATE TABLE tx_luxletter_domain_model_log (
 	user int(11) DEFAULT '0' NOT NULL,
 
 	status tinyint(4) unsigned DEFAULT '0' NOT NULL,
-	properties text NOT NULL,
+	properties text,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,
@@ -149,5 +149,5 @@ CREATE TABLE fe_groups (
 );
 
 CREATE TABLE pages (
-	luxletter_subject text NOT NULL,
+	luxletter_subject text,
 );


### PR DESCRIPTION
Resolves: #115 

I first thought of a major incompatibility with PHP8.0, but it seems that only the SQL definition of the TEXT and MEDIUMTEXT fields is the cause. 

Since TEXT fields in MySQL do not have a default value, but these fields are probably not necessarily set explicitly, but must not be NULL, the following behavior occurs. Tested with PHP8.0 and TYPO3 11LTS, but I assume, the problem might also occur on systems with PHP 7.* as I think the violation against the MySQL/MariaDB strict mode is the cause for the problem. 

As TEXT fields can't have a default value in MySQL/MariaDB and the value is not being set explicitly in every cause, you have to allow NULL as it's value. Maybe TYPO3 11/PHP 8.0 is there more strict in throwing errors.