### PR TITLE
Fix: show newsletter title on new line in link list

### DIFF
--- a/Resources/Private/Partials/Newsletter/Dashboard/Links.html
+++ b/Resources/Private/Partials/Newsletter/Dashboard/Links.html
@@ -10,7 +10,7 @@
 				<li class="list-group-item">
 					<span class="badge" style="float: right;" title="Overall">{groupedLink.count}</span>
 					<f:link.external uri="{groupedLink.target}">{groupedLink.target}</f:link.external>
-					({groupedLink.newsletter.title})
+					<br>({groupedLink.newsletter.title})
 				</li>
 			</f:for>
 		</ul>


### PR DESCRIPTION
Without this fix the links in the link list are very long and the newsletter title was split into two lines.