### PR TITLE
Fix: upsize height of bar diagrams on overview dashboard

### DIFF
--- a/Resources/Private/Partials/Newsletter/Dashboard/Click.html
+++ b/Resources/Private/Partials/Newsletter/Dashboard/Click.html
@@ -9,7 +9,7 @@
 		<canvas
 				id="luxletter-dashboard-click"
 				width="600"
-				height="200"
+				height="300"
 				data-chart="bar"
 				data-chart-label="Conversion"
 				data-chart-data="{luxletter:statistic.getListOfPropertiesFromNewsletters(newsletters:newsletters,property:'clickers')}"

--- a/Resources/Private/Partials/Newsletter/Dashboard/Open.html
+++ b/Resources/Private/Partials/Newsletter/Dashboard/Open.html
@@ -9,7 +9,7 @@
 		<canvas
 				id="luxletter-dashboard-open"
 				width="600"
-				height="200"
+				height="300"
 				data-chart="bar"
 				data-chart-label="Opener"
 				data-chart-data="{luxletter:statistic.getListOfPropertiesFromNewsletters(newsletters:newsletters,property:'openers')}"


### PR DESCRIPTION
The bar diagrams on the overview dashboard are on the left side to the link and newsletter lists.
The lists height is grater than the diagrams height. This fix gives the diagram and x-axis lables some extra height.