### PR TITLE
[FIX] Changes SQL Query for User Preview

### DIFF
--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -39,7 +39,6 @@ class UserRepository extends AbstractRepository
         /** @noinspection SqlDialectInspection */
         $sql = 'select * from ' . User::TABLE_NAME;
         $sql .= $this->getUserByGroupsWhereClause($groupIdentifiers, $lll);
-        $sql .= ' group by email';
         if ($limit > 0) {
             $sql .= ' limit ' . (int)$limit;
         }


### PR DESCRIPTION
Error received: Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'typo3.fe_users.uid' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

I removed the group by, because there will be only multiple same email adresses if there are multiple users with the same address. I think this is a problem with data quality on the side of the website