### PR TITLE
Feature/configurable doktype

### DIFF
--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -34,7 +34,7 @@ class PageRepository
             $results = $queryBuilder
                 ->select('*')
                 ->from(self::TABLE_NAME)
-                ->where('doktype=' . self::DOKTYPE_LUXLETTER . ' and sys_language_uid=0')
+                ->where('doktype=' . ConfigurationUtility::getMultilanguageNewsletterPageDoktype() . ' and sys_language_uid=0')
                 ->orderBy('title', 'desc')
                 ->executeQuery()
                 ->fetchAllAssociative();

--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -16,7 +16,6 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 class PageRepository
 {
     const TABLE_NAME = 'pages';
-    const DOKTYPE_LUXLETTER = 11;
 
     /**
      * Like

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -184,4 +184,12 @@ class ConfigurationUtility
     {
         return VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getNumericTypo3Version());
     }
+
+    public static function getMultilanguageNewsletterPageDoktype(): int
+    {
+        return (int)GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(
+            'luxletter',
+            'multiLanguageNewsletterPageDoktype'
+        );
+    }
 }

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -10,7 +10,7 @@ call_user_func(
          * Add new page doktype
          */
         if (\In2code\Luxletter\Utility\ConfigurationUtility::isMultiLanguageModeActivated()) {
-            $doktype = \In2code\Luxletter\Domain\Repository\PageRepository::DOKTYPE_LUXLETTER;
+            $doktype = \In2code\Luxletter\Utility\ConfigurationUtility::getMultilanguageNewsletterPageDoktype();
             $doktypeDefault = \TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_DEFAULT;
 
             \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(

--- a/Documentation/Installation/Index.md
+++ b/Documentation/Installation/Index.md
@@ -27,6 +27,7 @@ TYPO3 11.5 or 12.4 is required. The free extension lux can be also installed for
 | Add typenum                 | 1562349004    | Add typenum: Everytime you parse a html for a new newsletter, this type will be added (can be used in fluidStyledMailContent). This will work only for PID in origin, not for absolute URL.                                                         |
 | Show receiver action        | 1             | Show receiver action: Show link to receiver view in newsletter module. This view is maybe disturbing if you don't use extension lux in addition.                                                                                                    |
 | limitToContext              |               | Limit mails in context: If you run testinstances beside production, you can limit mail sending to a defined context (empty = no limit). Example "Production" or "Development/Docker".                                                               |
+| multiLanguageNewsletterPageDoktype | 11            | The value is used for the pages doktype field in your instance, if the default value 11 is already used, you can change it here.                                                                                                                    |
 
 <img src="../Images/documentation_installation_settings.png" width="800" alt="extension settings" />
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -15,3 +15,6 @@ receiverAction = 1
 
 # cat=basic//250; type=text; label= Limit mails in context: If you run testinstances beside production, you can limit mail sending to a defined context (empty = no limit). Example "Production" or "Development/Docker".
 limitToContext =
+
+# cat=basic//260; type=integer; label= Doktype used for Multilanguage Newsletter Pages: When there are already Newsletter Pages in the database, these entries must be migrated when the value is changed and cache must be cleared totally
+multiLanguageNewsletterPageDoktype = 11

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -111,7 +111,7 @@ call_user_func(
          * Add new page doktype
          */
         if (\In2code\Luxletter\Utility\ConfigurationUtility::isMultiLanguageModeActivated()) {
-            $doktype = \In2code\Luxletter\Domain\Repository\PageRepository::DOKTYPE_LUXLETTER;
+            $doktype = \In2code\Luxletter\Utility\ConfigurationUtility::getMultilanguageNewsletterPageDoktype();
             $GLOBALS['PAGES_TYPES'][$doktype] = [
                 'type' => 'web',
                 'allowedTables' => '*',


### PR DESCRIPTION
When the default doktype used for multilanguage newsletter pages is already used, the value can be changed now in the extension configuration.