### PR TITLE
[BUGFIX] Configure volume typo3var for darwin

### DIFF
--- a/.project/docker/docker-compose.darwin.yml
+++ b/.project/docker/docker-compose.darwin.yml
@@ -56,4 +56,5 @@ services:
       VIRTUAL_HOST: ${MAIL}
 
 volumes:
+  typo3var:
   mysql:


### PR DESCRIPTION
Darwin setup already uses this volume, but it was not configured.