### PR TITLE
[BUGFIX] Fix calculation of percentage of failed queue entries

### DIFF
--- a/Classes/Domain/Model/Newsletter.php
+++ b/Classes/Domain/Model/Newsletter.php
@@ -273,7 +273,7 @@ class Newsletter extends AbstractEntity
             $overall = $dispatched + $notDispatched;
             $result = 0;
             if ($overall > 0 && $failed > 0) {
-                $result = (int)(100 - ($failed / $overall * 100));
+                $result = (int)(($failed / $overall * 100));
             }
             $this->failuredProgress = $result;
         }


### PR DESCRIPTION
There was a fault in the calculation. It has to be the ratio of failed to the rest (dispatched + notDispatched).

Fixes: #180