### PR TITLE
[FEATURE] Log failure while sentout

### DIFF
--- a/Classes/Domain/Model/Log.php
+++ b/Classes/Domain/Model/Log.php
@@ -14,6 +14,7 @@ class Log extends AbstractEntity
     const TABLE_NAME = 'tx_luxletter_domain_model_log';
     const STATUS_DEFAULT = 0;
     const STATUS_DISPATCH = 100;
+    const STATUS_DISPATCH_FAILURE = 110;
     const STATUS_NEWSLETTEROPENING = 200;
     const STATUS_LINKOPENING = 300;
     const STATUS_UNSUBSCRIBE = 400;

--- a/Classes/Domain/Service/LogService.php
+++ b/Classes/Domain/Service/LogService.php
@@ -30,6 +30,17 @@ class LogService
     }
 
     /**
+     * @param Newsletter $newsletter
+     * @param User $user
+     * @return void
+     * @throws IllegalObjectTypeException
+     */
+    public function logNewsletterDispatchFailure(Newsletter $newsletter, User $user, string $message): void
+    {
+        $this->log($newsletter, $user, Log::STATUS_DISPATCH_FAILURE, ['exception' => $message]);
+    }
+
+    /**
      * Log the opening of a newsletter (via tracking pixel or when clicking a link) only once per newsletter and user
      *
      * @param Newsletter $newsletter

--- a/Classes/Mail/ProgressQueue.php
+++ b/Classes/Mail/ProgressQueue.php
@@ -106,6 +106,8 @@ class ProgressQueue
                     $this->sendNewsletterToReceiverInQueue($queue);
                     $this->markSent($queue);
                 } catch (Throwable $throwable) {
+                    $logService = GeneralUtility::makeInstance(LogService::class);
+                    $logService->logNewsletterDispatchFailure($queue->getNewsletter(), $queue->getUser(), $throwable->getMessage());
                     $this->increaseFailures($queue);
                 }
                 $progress->advance();


### PR DESCRIPTION
Skipping faulty queue entries is technically sufficient but of little help to the editor. He wants to know why the dispatch to a recipient failed. Luxletter already comes with a log system. In case of an error, the exception is now logged there.

Related: #186