### PR TITLE
[BUGFIX] Parse bodytext with lib.parseFunc_RTE

### DIFF
--- a/Resources/Private/FluidStyledMailContent/Partials/Bodytext.html
+++ b/Resources/Private/FluidStyledMailContent/Partials/Bodytext.html
@@ -1,3 +1,3 @@
 <div class="ce-bodytext">
-	<f:format.html parseFuncTSPath="lib.parseFunc">{data.bodytext}</f:format.html>
+	<f:format.html parseFuncTSPath="lib.parseFunc_RTE">{data.bodytext}</f:format.html>
 </div>


### PR DESCRIPTION
`tt_content.bodytext` normally contains HTML. According to FSC the currently by luxletter used `lib.parseFunc` "Creates persistent ParseFunc setup for non-HTML content." while `lib.parseFunc_RTE` "Creates persistent ParseFunc setup for RTE content (which is mainly HTML) based on the "default" transformation.". To support all features (and manipulations) of RTE content, we should follow TYPO3 default behaviour.

`tt_content.bodytext` will now be parsed by `lib.parseFunc_RTE`.

See: EXT:fluid_styled_content/Configuration/TypoScript/Helper/ParseFunc.typoscript

Related: https://projekte.in2code.de/issues/