### PR TITLE
[BUGFIX] Respect `asynchronousQueueStorage` if creating newsletter vi…

### DIFF
--- a/Classes/Command/CreateNewsletterFromOriginCommand.php
+++ b/Classes/Command/CreateNewsletterFromOriginCommand.php
@@ -9,6 +9,7 @@ use In2code\Luxletter\Domain\Factory\NewsletterFactory;
 use In2code\Luxletter\Domain\Service\QueueService;
 use In2code\Luxletter\Exception\InvalidUrlException;
 use In2code\Luxletter\Exception\MisconfigurationException;
+use In2code\Luxletter\Utility\ConfigurationUtility;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -72,9 +73,11 @@ class CreateNewsletterFromOriginCommand extends Command
         );
         $output->writeln('Newsletter with uid ' . $newsletter->getUid() . ' created');
 
-        $queueService = GeneralUtility::makeInstance(QueueService::class);
-        $queuedAmount = $queueService->addMailReceiversToQueue($newsletter, (int)$input->getArgument('language'));
-        $output->writeln('Added ' . $queuedAmount . ' queue records');
+        if (ConfigurationUtility::isAsynchronousQueueStorageActivated() === false) {
+            $queueService = GeneralUtility::makeInstance(QueueService::class);
+            $queuedAmount = $queueService->addMailReceiversToQueue($newsletter, (int)$input->getArgument('language'));
+            $output->writeln('Added ' . $queuedAmount . ' queue records');
+        }
         return 0;
     }
 }


### PR DESCRIPTION
…a CLI

The `asynchronousQueueStorage` option was introduced for large receiver volumes. The creation of the queue can take a long time here. Although CLI theoretically allows infinite script runtime, in the worst case a service/server restart can get in the way during this time and end the script run unexpectedly. For this reason, queues should also be set up asynchronously for newsletters created via CLI, if this has been configured accordingly in the instance.