### PR TITLE
[FEATURE] Enable overwriting of the body text for certain queue entries

### DIFF
--- a/Classes/Domain/Model/Queue.php
+++ b/Classes/Domain/Model/Queue.php
@@ -18,6 +18,7 @@ class Queue extends AbstractEntity
 
     protected ?DateTime $datetime = null;
     protected ?Newsletter $newsletter = null;
+    protected string $bodytext = '';
     protected ?User $user = null;
 
     public function getEmail(): string
@@ -39,6 +40,17 @@ class Queue extends AbstractEntity
     public function setNewsletter(Newsletter $newsletter): self
     {
         $this->newsletter = $newsletter;
+        return $this;
+    }
+
+    public function getBodytext(): string
+    {
+        return $this->bodytext;
+    }
+
+    public function setBodytext(string $bodytext): self
+    {
+        $this->bodytext = $bodytext;
         return $this;
     }
 

--- a/Classes/Mail/ProgressQueue.php
+++ b/Classes/Mail/ProgressQueue.php
@@ -182,7 +182,7 @@ class ProgressQueue
     protected function getBodyText(Queue $queue): string
     {
         $bodytext = $this->parseService->parseBodytext(
-            $queue->getNewsletter()->getBodytext(),
+            $queue->getBodytext() !== null ? $queue->getBodytext() : $queue->getNewsletter()->getBodytext(),
             [
                 'user' => $queue->getUser(),
                 'newsletter' => $queue->getNewsletter(),

--- a/Classes/Mail/ProgressQueue.php
+++ b/Classes/Mail/ProgressQueue.php
@@ -182,7 +182,7 @@ class ProgressQueue
     protected function getBodyText(Queue $queue): string
     {
         $bodytext = $this->parseService->parseBodytext(
-            $queue->getBodytext() !== null ? $queue->getBodytext() : $queue->getNewsletter()->getBodytext(),
+            $queue->getBodytext() !== '' ? $queue->getBodytext() : $queue->getNewsletter()->getBodytext(),
             [
                 'user' => $queue->getUser(),
                 'newsletter' => $queue->getNewsletter(),

--- a/Configuration/TCA/tx_luxletter_domain_model_queue.php
+++ b/Configuration/TCA/tx_luxletter_domain_model_queue.php
@@ -25,7 +25,7 @@ return [
         'hideTable' => 1,
     ],
     'types' => [
-        '1' => ['showitem' => 'email,newsletter,user,datetime,sent,failures'],
+        '1' => ['showitem' => 'email,newsletter,bodytext,user,datetime,sent,failures'],
     ],
     'columns' => [
         'email' => [
@@ -50,6 +50,18 @@ return [
                 'foreign_table_where' => 'AND sys_language_uid in (0,-1)',
                 'default' => 0,
                 'readOnly' => true,
+            ],
+        ],
+        'bodytext' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:luxletter/Resources/Private/Language/locallang_db.xlf:'
+                . Newsletter::TABLE_NAME . '.bodytext',
+            'config' => [
+                'type' => 'text',
+                'cols' => 800,
+                'rows' => 3,
+                'readOnly' => true,
+                'default' => '',
             ],
         ],
         'user' => [

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -140,6 +140,10 @@
 				<source>Failures</source>
 				<target state="translated">Fehlschläge</target>
 			</trans-unit>
+			<trans-unit id="tx_luxletter_domain_model_queue.bodytext">
+				<source>Bodytext</source>
+				<target state="translated">E-Mail Inhalt</target>
+			</trans-unit>
 
 			<trans-unit id="tx_luxletter_domain_model_log">
 				<source>Log</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -107,6 +107,9 @@
 			<trans-unit id="tx_luxletter_domain_model_queue.failures">
 				<source>Failures</source>
 			</trans-unit>
+			<trans-unit id="tx_luxletter_domain_model_queue.bodytext">
+				<source>Bodytext</source>
+			</trans-unit>
 
 			<trans-unit id="tx_luxletter_domain_model_log">
 				<source>Log</source>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -41,6 +41,7 @@ CREATE TABLE tx_luxletter_domain_model_queue (
 
 	email varchar(255) DEFAULT '' NOT NULL,
 	newsletter int(11) DEFAULT '0' NOT NULL,
+	bodytext mediumtext,
 	user int(11) DEFAULT '0' NOT NULL,
 	datetime int(11) DEFAULT '0' NOT NULL,
 	sent tinyint(4) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
The change makes it possible for individual queue entries to have a different mail content. This is only the structural preparation, a corresponding feature is not yet implemented. The possibility can be used via the existing events.