### PR TITLE
Make Luxletter news templating compatible with tx_news v11

### DIFF
--- a/Configuration/TypoScript/FluidStyledMailContent/setup.typoscript
+++ b/Configuration/TypoScript/FluidStyledMailContent/setup.typoscript
@@ -44,6 +44,7 @@ plugin.tx_news {
     }
   }
 }
+tt_content.news_pi1.templateName = List
 [end]
 
 fluidStyledMailContent = PAGE

--- a/Resources/Private/FluidStyledMailContent/Templates/List.html
+++ b/Resources/Private/FluidStyledMailContent/Templates/List.html
@@ -1,6 +1,6 @@
-<f:if condition="{data.list_type} == 'news_pi1'">
+<f:if condition="{data.CType} == 'news_pi1'">
     <f:then>
-        <f:cObject typoscriptObjectPath="tt_content.list.20.{data.list_type}" data="{data}" table="tt_content" />
+        <f:cObject typoscriptObjectPath="tt_content.{data.CType}.20" data="{data}" table="tt_content" />
     </f:then>
     <f:else>
         <f:render partial="NotYetSupported" arguments="{_all}"/>


### PR DESCRIPTION
This fixes the error: 

`
tt_content.CType=news_pi1 is not yet supported in FluidStyledMailContent (Part of EXT:luxletter)
`

when you use extension news 11.x.x