### PR TITLE
[BUGFIX] Proper check for existence

### DIFF
--- a/Classes/Domain/Service/UnsubscribeUrlService.php
+++ b/Classes/Domain/Service/UnsubscribeUrlService.php
@@ -88,7 +88,7 @@ class UnsubscribeUrlService
      */
     protected function getPidUnsubscribe(): int
     {
-        $unsubscribePid = (int)$this->site->getConfiguration()['luxletterUnsubscribePid'] ?? 0;
+        $unsubscribePid = (int)($this->site->getConfiguration()['luxletterUnsubscribePid'] ?? 0);
         if ($unsubscribePid === 0) {
             throw new MisconfigurationException(
                 'No unsubscribe page identifier found in site configuration',


### PR DESCRIPTION
the typecast has a higher priority than the ?? operator, therefore some parentheses must be used