### PR TITLE
[!!!][TASK] Reduce size of reference index

### DIFF
--- a/Classes/TCA/PreventReferenceIndex.php
+++ b/Classes/TCA/PreventReferenceIndex.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+namespace In2code\Luxletter\TCA;
+
+use TYPO3\CMS\Core\DataHandling\Event\IsTableExcludedFromReferenceIndexEvent;
+
+/**
+ * Prevent reference index records for some Luxletter tables, to keep database small.
+ */
+class PreventReferenceIndex
+{
+    protected array $excludedTables = [
+        'tx_luxletter_domain_model_link',
+        'tx_luxletter_domain_model_log',
+        'tx_luxletter_domain_model_queue',
+    ];
+
+    public function __invoke(IsTableExcludedFromReferenceIndexEvent $event): void
+    {
+        if (in_array($event->getTable(), $this->excludedTables, true)) {
+            $event->markAsExcluded();
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -32,6 +32,11 @@ services:
       - name: 'console.command'
         command: 'luxletter:queue'
 
+  In2code\Luxletter\TCA\PreventReferenceIndex:
+    tags:
+      - name: 'event.listener'
+        identifier: 'luxletter/preventReferenceIndex'
+
   In2code\Luxletter\Domain\Factory\NewsletterFactory:
     public: true
 


### PR DESCRIPTION
This excludes the luxletter link, log and queue tables from the reference index.
Thereby the size of the reference index is massively reduced.

For this patch to become effective it is necessary to manually run:
* SQL:
  ```sql
  DELETE FROM `sys_refindex`
  WHERE `tablename` IN (
    'tx_luxletter_domain_model_link',
    'tx_luxletter_domain_model_log',
    'tx_luxletter_domain_model_queue'
  );
  ```
* `vendor/bin/typo3 referenceindex:update`

This fixes https://github.com/in2code-de/luxletter/issues/130