### PR TITLE
[BUGFIX] Close connection to SMTP-server

### DIFF
--- a/Classes/Mail/MailMessage.php
+++ b/Classes/Mail/MailMessage.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 namespace In2code\Luxletter\Mail;
 
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use TYPO3\CMS\Core\Mail\MailMessage as MailMessageCore;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -16,11 +17,27 @@ class MailMessage extends MailMessageCore
         $this->mailer = GeneralUtility::makeInstance(Mailer::class);
     }
 
+    /**
+     * @return bool
+     * @throws TransportExceptionInterface
+     */
     public function send(): bool
     {
         $this->initializeMailer();
         $this->sent = false;
-        $this->mailer->send($this);
+        try {
+            $this->mailer->send($this);
+        } finally {
+            // In case of SMTP always close the connection to the SMTP-server, especially in case of failure.
+            // This prevents "421 Too many concurrent SMTP connections".
+            if (method_exists($this->mailer->getTransport(), 'stop')) {
+                // See Symfony\Component\Mailer\Transport\Smtp\SmtpTransport::stop()
+                // https://github.com/symfony/mailer/blob/f466aa7c9ad74159986f91fda49a364b3bd9a2b6/Transport/Smtp/SmtpTransport.php#L295-L311
+                // Compare to Symfony\Component\Mailer\Transport\Smtp\SmtpTransport::ping()
+                // https://github.com/symfony/mailer/blob/f466aa7c9ad74159986f91fda49a364b3bd9a2b6/Transport/Smtp/SmtpTransport.php#L313-L324
+                $this->mailer->getTransport()->stop();
+            }
+        }
         $sentMessage = $this->mailer->getSentMessage();
         if ($sentMessage) {
             $this->sent = true;

--- a/Classes/Mail/ProgressQueue.php
+++ b/Classes/Mail/ProgressQueue.php
@@ -17,6 +17,7 @@ use In2code\Luxletter\Utility\ConfigurationUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Throwable;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
@@ -131,6 +132,7 @@ class ProgressQueue
      * @throws InvalidSlotReturnException
      * @throws MisconfigurationException
      * @throws SiteNotFoundException
+     * @throws TransportExceptionInterface
      */
     protected function sendNewsletterToReceiverInQueue(Queue $queue): void
     {

--- a/Classes/Mail/SendMail.php
+++ b/Classes/Mail/SendMail.php
@@ -13,6 +13,7 @@ use In2code\Luxletter\Events\SendMailSendNewsletterBeforeMailMessageEvent;
 use In2code\Luxletter\Exception\MisconfigurationException;
 use In2code\Luxletter\Utility\ConfigurationUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -52,6 +53,7 @@ class SendMail
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      * @throws MisconfigurationException
+     * @throws TransportExceptionInterface
      */
     public function sendNewsletter(array $receiver): bool
     {

--- a/Classes/Mail/TestMail.php
+++ b/Classes/Mail/TestMail.php
@@ -13,6 +13,7 @@ use In2code\Luxletter\Exception\ApiConnectionException;
 use In2code\Luxletter\Exception\InvalidUrlException;
 use In2code\Luxletter\Exception\MisconfigurationException;
 use In2code\Luxletter\Utility\ConfigurationUtility;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -69,6 +70,7 @@ class TestMail
      * @throws InvalidUrlException
      * @throws MisconfigurationException
      * @throws ExceptionDbalDriver
+     * @throws TransportExceptionInterface
      */
     public function preflight(string $origin, string $layout, int $configuration, string $subject, string $email): bool
     {


### PR DESCRIPTION
This closes the connection to the SMTP-server, especially in case of failure.
This prevents "421 Too many concurrent SMTP connections". 

This fixes https://github.com/in2code-de/luxletter/issues/247