### PR TITLE
[TASK] Remove deprecated Extbase exceptions from PHPDoc blocks

### DIFF
--- a/Classes/Command/QueueCommand.php
+++ b/Classes/Command/QueueCommand.php
@@ -16,12 +16,9 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExis
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException;
-use TYPO3\CMS\Extbase\Object\Exception;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
-use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotException;
-use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotReturnException;
 
 class QueueCommand extends Command
 {
@@ -50,12 +47,9 @@ class QueueCommand extends Command
      * @throws IllegalObjectTypeException
      * @throws InvalidConfigurationTypeException
      * @throws InvalidQueryException
-     * @throws InvalidSlotException
-     * @throws InvalidSlotReturnException
      * @throws UnknownObjectException
      * @throws ArgumentMissingException
      * @throws MisconfigurationException
-     * @throws Exception
      * @throws SiteNotFoundException
      */
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/Classes/Domain/Repository/LinkRepository.php
+++ b/Classes/Domain/Repository/LinkRepository.php
@@ -7,7 +7,6 @@ use In2code\Luxletter\Domain\Model\Link;
 use In2code\Luxletter\Exception\ArgumentMissingException;
 use In2code\Luxletter\Utility\DatabaseUtility;
 use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Extbase\Object\Exception;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 
 class LinkRepository extends AbstractRepository
@@ -47,7 +46,6 @@ class LinkRepository extends AbstractRepository
      * @return void
      * @throws IllegalObjectTypeException
      * @throws ArgumentMissingException
-     * @throws Exception
      */
     public function add($object)
     {

--- a/Classes/Mail/ProgressQueue.php
+++ b/Classes/Mail/ProgressQueue.php
@@ -23,12 +23,9 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExis
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException;
-use TYPO3\CMS\Extbase\Object\Exception;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
-use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotException;
-use TYPO3\CMS\Extbase\SignalSlot\Exception\InvalidSlotReturnException;
 
 /**
  * Class ProgressQueue
@@ -78,14 +75,11 @@ class ProgressQueue
      * @param int $newsletterIdentifier
      * @return int Number of progressed queued mails
      * @throws ArgumentMissingException
-     * @throws Exception
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      * @throws IllegalObjectTypeException
      * @throws InvalidConfigurationTypeException
      * @throws InvalidQueryException
-     * @throws InvalidSlotException
-     * @throws InvalidSlotReturnException
      * @throws MisconfigurationException
      * @throws SiteNotFoundException
      * @throws UnknownObjectException
@@ -122,13 +116,10 @@ class ProgressQueue
      * @param Queue $queue
      * @return void
      * @throws ArgumentMissingException
-     * @throws Exception
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      * @throws IllegalObjectTypeException
      * @throws InvalidConfigurationTypeException
-     * @throws InvalidSlotException
-     * @throws InvalidSlotReturnException
      * @throws MisconfigurationException
      * @throws SiteNotFoundException
      */
@@ -170,13 +161,10 @@ class ProgressQueue
      * @param Queue $queue
      * @return string
      * @throws ArgumentMissingException
-     * @throws Exception
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      * @throws IllegalObjectTypeException
      * @throws InvalidConfigurationTypeException
-     * @throws InvalidSlotException
-     * @throws InvalidSlotReturnException
      * @throws MisconfigurationException
      * @throws SiteNotFoundException
      */
@@ -204,12 +192,9 @@ class ProgressQueue
      * @param string $bodytext
      * @return string
      * @throws ArgumentMissingException
-     * @throws Exception
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      * @throws IllegalObjectTypeException
-     * @throws InvalidSlotException
-     * @throws InvalidSlotReturnException
      * @throws MisconfigurationException
      * @throws SiteNotFoundException
      */

--- a/Classes/ViewHelpers/Format/CropBySelectionViewHelper.php
+++ b/Classes/ViewHelpers/Format/CropBySelectionViewHelper.php
@@ -8,7 +8,6 @@ use DOMNode;
 use DomXPath;
 use In2code\Luxletter\Utility\DomDocumentUtility;
 use In2code\Luxletter\Utility\ObjectUtility;
-use TYPO3\CMS\Extbase\Object\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -40,7 +39,6 @@ class CropBySelectionViewHelper extends AbstractViewHelper
 
     /**
      * @return string
-     * @throws Exception
      */
     public function render(): string
     {
@@ -77,7 +75,6 @@ class CropBySelectionViewHelper extends AbstractViewHelper
     /**
      * @param string $string
      * @return string
-     * @throws Exception
      */
     protected function cropText(string $string): string
     {


### PR DESCRIPTION
Deprecated Extbase Object and SignalSlot exceptions were removed in TYPO3 v12, see [1].
This removes these exceptions from PHPDoc blocks.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html