### PR TITLE
[BUGFIX] Correct return type of getPageRowFromPageIdentifier()

### DIFF
--- a/Classes/Domain/Service/PermissionTrait.php
+++ b/Classes/Domain/Service/PermissionTrait.php
@@ -72,7 +72,11 @@ trait PermissionTrait
 
         $pageIdentifier = $this->getPageIdentifierFromRecord($identifier, $table);
         if ($pageIdentifier > 0) {
-            return $this->isAuthenticatedForPageRow($this->getPageRowFromPageIdentifier($pageIdentifier));
+            $pageRecord = $this->getPageRowFromPageIdentifier($pageIdentifier);
+            if ($pageRecord === []) {
+                return false;
+            }
+            return $this->isAuthenticatedForPageRow($pageRecord);
         }
         return false;
     }

--- a/Classes/Domain/Service/PermissionTrait.php
+++ b/Classes/Domain/Service/PermissionTrait.php
@@ -110,13 +110,13 @@ trait PermissionTrait
 
     /**
      * @param int $identifier
-     * @return array|int
+     * @return array
      * @throws ExceptionDbal
      */
     protected function getPageRowFromPageIdentifier(int $identifier): array
     {
         $queryBuilder = DatabaseUtility::getQueryBuilderForTable('pages');
-        return (array)$queryBuilder
+        $row = $queryBuilder
             ->select('*')
             ->from('pages')
             ->where(
@@ -125,5 +125,6 @@ trait PermissionTrait
             ->setMaxResults(1)
             ->executeQuery()
             ->fetchAssociative();
+        return $row ?: [];
     }
 }


### PR DESCRIPTION
The case where fetchAssociative() returns FALSE was handled incorrectly. Instead of an empty array, a single-element array was returned. This could lead to errors or exceptions in further processing of the return value.

Now either the pages record is returned or an *empty* array.