### PR TITLE
Make luxletter PostgreSQL compatible

### DIFF
--- a/Classes/Domain/Repository/LogRepository.php
+++ b/Classes/Domain/Repository/LogRepository.php
@@ -25,14 +25,14 @@ class LogRepository extends AbstractRepository
     public function getNumberOfReceivers(Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = "select count(distinct user) "
-            . " from " . Log::TABLE_NAME . " l"
-            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
-            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
-            . " where l.deleted=0 and l.status=" . Log::STATUS_DISPATCH
+        $sql = 'select count(distinct user) '
+            . ' from ' . Log::TABLE_NAME . ' l'
+            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
+            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
+            . ' where l.deleted=0 and l.status=' . Log::STATUS_DISPATCH
             . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
-            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp()
-            . " limit 1";
+            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp()
+            . ' limit 1';
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -52,16 +52,16 @@ class LogRepository extends AbstractRepository
     public function getGroupedLinksByHref(Filter $filter): array
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = "select count(*) as count, l.properties, l.newsletter, MAX(l.uid) uid"
-            . " from " . Log::TABLE_NAME . " l"
-            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
-            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
-            . " where l.deleted=0 and l.status=" . Log::STATUS_LINKOPENING
+        $sql = 'select count(*) as count, l.properties, l.newsletter, MAX(l.uid) uid'
+            . ' from ' . Log::TABLE_NAME . ' l'
+            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
+            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
+            . ' where l.deleted=0 and l.status=' . Log::STATUS_LINKOPENING
             . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
-            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp()
-            . " group by l.properties, l.newsletter"
-            . " order by count desc"
-            . " limit " . $filter->getLimit();
+            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp()
+            . ' group by l.properties, l.newsletter'
+            . ' order by count desc'
+            . ' limit ' . $filter->getLimit();
         $results = $connection->executeQuery($sql)->fetchAllAssociative();
         $nlRepository = GeneralUtility::makeInstance(NewsletterRepository::class);
         foreach ($results as &$result) {
@@ -79,14 +79,14 @@ class LogRepository extends AbstractRepository
     public function getOverallOpenings(Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = "select count(distinct (newsletter, user))"
-            . " from " . Log::TABLE_NAME . " l"
-            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
-            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
-            . " where l.deleted = 0"
-            . " and l.status IN (" . Log::STATUS_NEWSLETTEROPENING . "," . Log::STATUS_LINKOPENING . ")"
+        $sql = 'select count(distinct (newsletter, user))'
+            . ' from ' . Log::TABLE_NAME . ' l'
+            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
+            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
+            . ' where l.deleted = 0'
+            . ' and l.status IN (' . Log::STATUS_NEWSLETTEROPENING . ',' . Log::STATUS_LINKOPENING . ')'
             . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
-            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp();
+            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp();
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -98,13 +98,13 @@ class LogRepository extends AbstractRepository
     public function getOpeningsByClickers(Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = "select count(distinct (newsletter, user))"
-            . " from " . Log::TABLE_NAME . " l"
-            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
-            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
-            . " where l.deleted = 0 and l.status=" . Log::STATUS_LINKOPENING
+        $sql = 'select count(distinct (newsletter, user))'
+            . ' from ' . Log::TABLE_NAME . ' l'
+            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
+            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
+            . ' where l.deleted = 0 and l.status=' . Log::STATUS_LINKOPENING
             . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
-            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp();
+            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp();
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -147,13 +147,13 @@ class LogRepository extends AbstractRepository
     protected function getOverallAmountByLogStatus(array $status, Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = "select count(l.uid)"
-            . " from " . Log::TABLE_NAME . " l"
-            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
-            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
-            . " where l.deleted = 0 and l.status in (" . ArrayUtility::convertArrayToIntegerList($status) . ")"
+        $sql = 'select count(l.uid)'
+            . ' from ' . Log::TABLE_NAME . ' l'
+            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
+            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
+            . ' where l.deleted = 0 and l.status in (' . ArrayUtility::convertArrayToIntegerList($status) . ')'
             . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
-            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp();
+            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp();
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -275,7 +275,7 @@ class LogRepository extends AbstractRepository
         $uid = (int)$queryBuilder
             ->select('uid')
             ->from(Log::TABLE_NAME)
-            ->where("newsletter=" . (int)$newsletterIdentifier . " and user='" . (int)$userIdentifier . "' and status='" . (int)$status . "'")
+            ->where('newsletter=' . (int)$newsletterIdentifier . " and user='" . (int)$userIdentifier . "' and status='" . (int)$status . "'")
             ->setMaxResults(1)
             ->executeQuery()
             ->fetchOne();
@@ -297,8 +297,8 @@ class LogRepository extends AbstractRepository
             $sqlSelectColumns = 'distinct (newsletter, user)';
         }
         return $connection->executeQuery(
-            "select " . $sqlSelectColumns . " from " . Log::TABLE_NAME .
-            " where deleted=0 and status in (" . implode(",", $status) . ") and newsletter=" . (int)$newsletter->getUid()
+            'select ' . $sqlSelectColumns . ' from ' . Log::TABLE_NAME .
+            ' where deleted=0 and status in (' . implode(',', $status) . ') and newsletter=' . (int)$newsletter->getUid()
         )->fetchAllAssociative();
     }
 
@@ -312,13 +312,13 @@ class LogRepository extends AbstractRepository
     public function findRawByUser(User $user, array $statusWhitelist = [], array $statusBlacklist = []): array
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = "select * from " . Log::TABLE_NAME . " where deleted=0 and user='" . (int)$user->getUid() . "'";
+        $sql = 'select * from ' . Log::TABLE_NAME . " where deleted=0 and user='" . (int)$user->getUid() . "'";
         if ($statusWhitelist !== []) {
-            $sql .= " and status in (" . implode(",", $statusWhitelist) . ")";
+            $sql .= ' and status in (' . implode(',', $statusWhitelist) . ')';
         } elseif ($statusBlacklist !== []) {
-            $sql .= " and status not in (" . implode(",", $statusBlacklist) . ")";
+            $sql .= ' and status not in (' . implode(',', $statusBlacklist) . ')';
         }
-        $sql .= " order by crdate desc";
+        $sql .= ' order by crdate desc';
         return (array)$connection->executeQuery($sql)->fetchAllAssociative();
     }
 

--- a/Classes/Domain/Repository/LogRepository.php
+++ b/Classes/Domain/Repository/LogRepository.php
@@ -25,14 +25,14 @@ class LogRepository extends AbstractRepository
     public function getNumberOfReceivers(Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = 'select count(distinct user) '
-            . ' from ' . Log::TABLE_NAME . ' l'
-            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
-            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
-            . ' where l.deleted=0 and l.status=' . Log::STATUS_DISPATCH
-            . ' and c.site in ("' . implode('","', $filter->getSitesForFilter()) . '")'
-            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp()
-            . ' limit 1';
+        $sql = "select count(distinct user) "
+            . " from " . Log::TABLE_NAME . " l"
+            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
+            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
+            . " where l.deleted=0 and l.status=" . Log::STATUS_DISPATCH
+            . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
+            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp()
+            . " limit 1";
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -52,16 +52,16 @@ class LogRepository extends AbstractRepository
     public function getGroupedLinksByHref(Filter $filter): array
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = 'select count(*) as count, l.properties, l.newsletter, MAX(l.uid) uid'
-            . ' from ' . Log::TABLE_NAME . ' l'
-            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
-            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
-            . ' where l.deleted=0 and l.status=' . Log::STATUS_LINKOPENING
-            . ' and c.site in ("' . implode('","', $filter->getSitesForFilter()) . '")'
-            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp()
-            . ' group by l.properties, l.newsletter'
-            . ' order by count desc'
-            . ' limit ' . $filter->getLimit();
+        $sql = "select count(*) as count, l.properties, l.newsletter, MAX(l.uid) uid"
+            . " from " . Log::TABLE_NAME . " l"
+            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
+            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
+            . " where l.deleted=0 and l.status=" . Log::STATUS_LINKOPENING
+            . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
+            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp()
+            . " group by l.properties, l.newsletter"
+            . " order by count desc"
+            . " limit " . $filter->getLimit();
         $results = $connection->executeQuery($sql)->fetchAllAssociative();
         $nlRepository = GeneralUtility::makeInstance(NewsletterRepository::class);
         foreach ($results as &$result) {
@@ -79,14 +79,14 @@ class LogRepository extends AbstractRepository
     public function getOverallOpenings(Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = 'select count(distinct newsletter, user)'
-            . ' from ' . Log::TABLE_NAME . ' l'
-            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
-            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
-            . ' where l.deleted = 0'
-            . ' and l.status IN (' . Log::STATUS_NEWSLETTEROPENING . ',' . Log::STATUS_LINKOPENING . ')'
-            . ' and c.site in ("' . implode('","', $filter->getSitesForFilter()) . '")'
-            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp();
+        $sql = "select count(distinct (newsletter, user))"
+            . " from " . Log::TABLE_NAME . " l"
+            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
+            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
+            . " where l.deleted = 0"
+            . " and l.status IN (" . Log::STATUS_NEWSLETTEROPENING . "," . Log::STATUS_LINKOPENING . ")"
+            . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
+            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp();
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -98,13 +98,13 @@ class LogRepository extends AbstractRepository
     public function getOpeningsByClickers(Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = 'select count(distinct newsletter, user)'
-            . ' from ' . Log::TABLE_NAME . ' l'
-            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
-            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
-            . ' where l.deleted = 0 and l.status=' . Log::STATUS_LINKOPENING
-            . ' and c.site in ("' . implode('","', $filter->getSitesForFilter()) . '")'
-            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp();
+        $sql = "select count(distinct (newsletter, user))"
+            . " from " . Log::TABLE_NAME . " l"
+            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
+            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
+            . " where l.deleted = 0 and l.status=" . Log::STATUS_LINKOPENING
+            . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
+            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp();
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -147,13 +147,13 @@ class LogRepository extends AbstractRepository
     protected function getOverallAmountByLogStatus(array $status, Filter $filter): int
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = 'select count(l.uid)'
-            . ' from ' . Log::TABLE_NAME . ' l'
-            . ' left join ' . Newsletter::TABLE_NAME . ' nl on nl.uid=l.newsletter'
-            . ' left join ' . Configuration::TABLE_NAME . ' c on nl.configuration=c.uid'
-            . ' where l.deleted = 0 and l.status in (' . ArrayUtility::convertArrayToIntegerList($status) . ')'
-            . ' and c.site in ("' . implode('","', $filter->getSitesForFilter()) . '")'
-            . ' and nl.crdate>' . $filter->getTimeDateStart()->getTimestamp();
+        $sql = "select count(l.uid)"
+            . " from " . Log::TABLE_NAME . " l"
+            . " left join " . Newsletter::TABLE_NAME . " nl on nl.uid=l.newsletter"
+            . " left join " . Configuration::TABLE_NAME . " c on nl.configuration=c.uid"
+            . " where l.deleted = 0 and l.status in (" . ArrayUtility::convertArrayToIntegerList($status) . ")"
+            . " and c.site in ('" . implode("','", $filter->getSitesForFilter()) . "')"
+            . " and nl.crdate>" . $filter->getTimeDateStart()->getTimestamp();
         return (int)$connection->executeQuery($sql)->fetchOne();
     }
 
@@ -275,7 +275,7 @@ class LogRepository extends AbstractRepository
         $uid = (int)$queryBuilder
             ->select('uid')
             ->from(Log::TABLE_NAME)
-            ->where('newsletter=' . $newsletterIdentifier . ' and user=' . $userIdentifier . ' and status=' . $status)
+            ->where("newsletter=" . (int)$newsletterIdentifier . " and user='" . (int)$userIdentifier . "' and status='" . (int)$status . "'")
             ->setMaxResults(1)
             ->executeQuery()
             ->fetchOne();
@@ -294,11 +294,11 @@ class LogRepository extends AbstractRepository
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
         $sqlSelectColumns = '*';
         if ($distinctMails === true) {
-            $sqlSelectColumns = 'distinct newsletter, user';
+            $sqlSelectColumns = 'distinct (newsletter, user)';
         }
         return $connection->executeQuery(
-            'select ' . $sqlSelectColumns . ' from ' . Log::TABLE_NAME .
-            ' where deleted=0 and status in (' . implode(',', $status) . ') and newsletter=' . $newsletter->getUid()
+            "select " . $sqlSelectColumns . " from " . Log::TABLE_NAME .
+            " where deleted=0 and status in (" . implode(",", $status) . ") and newsletter=" . (int)$newsletter->getUid()
         )->fetchAllAssociative();
     }
 
@@ -312,13 +312,13 @@ class LogRepository extends AbstractRepository
     public function findRawByUser(User $user, array $statusWhitelist = [], array $statusBlacklist = []): array
     {
         $connection = DatabaseUtility::getConnectionForTable(Log::TABLE_NAME);
-        $sql = 'select * from ' . Log::TABLE_NAME . ' where deleted=0 and user=' . $user->getUid();
+        $sql = "select * from " . Log::TABLE_NAME . " where deleted=0 and user='" . (int)$user->getUid() . "'";
         if ($statusWhitelist !== []) {
-            $sql .= ' and status in (' . implode(',', $statusWhitelist) . ')';
+            $sql .= " and status in (" . implode(",", $statusWhitelist) . ")";
         } elseif ($statusBlacklist !== []) {
-            $sql .= ' and status not in (' . implode(',', $statusBlacklist) . ')';
+            $sql .= " and status not in (" . implode(",", $statusBlacklist) . ")";
         }
-        $sql .= ' order by crdate desc';
+        $sql .= " order by crdate desc";
         return (array)$connection->executeQuery($sql)->fetchAllAssociative();
     }
 

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -94,7 +94,7 @@ class QueueRepository extends AbstractRepository
         return (int)$queryBuilder
             ->select('uid')
             ->from(Queue::TABLE_NAME)
-            ->where('newsletter=' . $newsletter->getUid() . ' and user=' . $user->getUid())
+            ->where("newsletter=" . (int)$newsletter->getUid() . " and user='" . (int)$user->getUid() . "'")
             ->setMaxResults(1)
             ->executeQuery()
             ->fetchOne() > 0;

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -94,7 +94,7 @@ class QueueRepository extends AbstractRepository
         return (int)$queryBuilder
             ->select('uid')
             ->from(Queue::TABLE_NAME)
-            ->where("newsletter=" . (int)$newsletter->getUid() . " and user='" . (int)$user->getUid() . "'")
+            ->where('newsletter=' . (int)$newsletter->getUid() . " and user='" . (int)$user->getUid() . "'")
             ->setMaxResults(1)
             ->executeQuery()
             ->fetchOne() > 0;

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -88,15 +88,15 @@ class UserRepository extends AbstractRepository
         if ($groupIdentifiers !== []) {
             $connection = DatabaseUtility::getConnectionForTable(User::TABLE_NAME);
             /** @noinspection SqlDialectInspection */
-            $sql = "select count(distinct email) from " . User::TABLE_NAME;
+            $sql = 'select count(distinct email) from ' . User::TABLE_NAME;
             $sub = '';
             foreach ($groupIdentifiers as $identifier) {
                 if ($sub !== '') {
-                    $sub .= " or ";
+                    $sub .= ' or ';
                 }
                 $sub = "((',' || usergroup || ',') LIKE '%," . (int)$identifier . ",%')";
             }
-            $sql .= " where deleted=0 and disable=0 and email like '%@%' and (" . $sub . ")";
+            $sql .= " where deleted=0 and disable=0 and email like '%@%' and (" . $sub . ')';
             return (int)$connection->executeQuery($sql)->fetchOne();
         }
         return 0;

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -88,15 +88,15 @@ class UserRepository extends AbstractRepository
         if ($groupIdentifiers !== []) {
             $connection = DatabaseUtility::getConnectionForTable(User::TABLE_NAME);
             /** @noinspection SqlDialectInspection */
-            $sql = 'select count(distinct email) from ' . User::TABLE_NAME;
+            $sql = "select count(distinct email) from " . User::TABLE_NAME;
             $sub = '';
             foreach ($groupIdentifiers as $identifier) {
                 if ($sub !== '') {
-                    $sub .= ' or ';
+                    $sub .= " or ";
                 }
-                $sub .= 'find_in_set(' . (int)$identifier . ',usergroup)';
+                $sub = "((',' || usergroup || ',') LIKE '%," . (int)$identifier . ",%')";
             }
-            $sql .= ' where deleted=0 and disable=0 and email like "%@%" and (' . $sub . ')';
+            $sql .= " where deleted=0 and disable=0 and email like '%@%' and (" . $sub . ")";
             return (int)$connection->executeQuery($sql)->fetchOne();
         }
         return 0;

--- a/Classes/Domain/Repository/UsergroupRepository.php
+++ b/Classes/Domain/Repository/UsergroupRepository.php
@@ -19,9 +19,9 @@ class UsergroupRepository extends AbstractRepository
         $result = [];
         if ($usergroupIdentifiers !== []) {
             $connection = DatabaseUtility::getConnectionForTable(Usergroup::TABLE_NAME);
-            $sql = "select * from " . Usergroup::TABLE_NAME
-                . " where uid in (" . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ")"
-                . " order by FIELD(uid, " . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ")";
+            $sql = 'select * from ' . Usergroup::TABLE_NAME
+                . ' where uid in (' . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ')'
+                . ' order by FIELD(uid, ' . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ')';
             $records = $connection->executeQuery($sql)->fetchAllAssociative();
             foreach ($records as $record) {
                 $user = $this->findByUid($record['uid']);

--- a/Classes/Domain/Repository/UsergroupRepository.php
+++ b/Classes/Domain/Repository/UsergroupRepository.php
@@ -19,9 +19,9 @@ class UsergroupRepository extends AbstractRepository
         $result = [];
         if ($usergroupIdentifiers !== []) {
             $connection = DatabaseUtility::getConnectionForTable(Usergroup::TABLE_NAME);
-            $sql = 'select * from ' . Usergroup::TABLE_NAME
-                . ' where uid in (' . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ')'
-                . ' order by FIELD(uid, ' . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ')';
+            $sql = "select * from " . Usergroup::TABLE_NAME
+                . " where uid in (" . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ")"
+                . " order by FIELD(uid, " . ArrayUtility::convertArrayToIntegerList($usergroupIdentifiers) . ")";
             $records = $connection->executeQuery($sql)->fetchAllAssociative();
             foreach ($records as $record) {
                 $user = $this->findByUid($record['uid']);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,14 +11,14 @@ $EM_CONF[$_EXTKEY] = [
     'state' => 'stable',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99'
+            'typo3' => '12.4.0-13.4.99',
         ],
         'conflicts' => [
-            'news' => '9.0.0-10.99.99'
+            'news' => '9.0.0-10.99.99',
         ],
         'suggests' => [
             'lux' => '0.0.0-0.0.0',
-            'dashboard' => '0.0.0-0.0.0'
-        ]
-    ]
+            'dashboard' => '0.0.0-0.0.0',
+        ],
+    ],
 ];


### PR DESCRIPTION
Currently, a lot of errors are reported when using Typo3 with PostgreSQL. This is mainly due to the usage of "wrong" quotation marks.

These changes enable the usage of luxletter even with PostgreSQL.