### PR TITLE
[FIX] Fix Yoast SEO Snippet Preview for Newsletter doktype

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -87,4 +87,8 @@ if (ConfigurationUtility::isMultiLanguageModeActivated()) {
     ExtensionManagementUtility::addUserTSConfig(
         'options.pageTree.doktypesToShowInNewPageDragArea := addToList(' . $doktype . ')'
     );
+
+    if (ExtensionManagementUtility::isLoaded('yoast_seo')) {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']['luxletter'] = $doktype;
+    }
 }


### PR DESCRIPTION
PR adds the Newsletter doktype to Yoast Seo's allowed doktypes. 

resolves #260 


https://docs.typo3.org/p/yoast-seo-for-typo3/yoast_seo/12.1/en-us/Configuration/SnippetPreview/Index.html#enable-snippet-preview-on-specific-page-types